### PR TITLE
Ensure component page works with custom component types

### DIFF
--- a/app/packages/app/src/components/catalog/EntityPage.tsx
+++ b/app/packages/app/src/components/catalog/EntityPage.tsx
@@ -230,7 +230,15 @@ const componentPage = (
       {serviceEntityPage}
     </EntitySwitch.Case>
 
+    <EntitySwitch.Case if={isComponentType('backend')}>
+      {serviceEntityPage}
+    </EntitySwitch.Case>
+
     <EntitySwitch.Case if={isComponentType('website')}>
+      {websiteEntityPage}
+    </EntitySwitch.Case>
+
+    <EntitySwitch.Case if={isComponentType('frontend')}>
       {websiteEntityPage}
     </EntitySwitch.Case>
 


### PR DESCRIPTION
We have used custom types in our components (frontend/backend). This change aligns our types with the OOTB Backstage types on the component page.

[AB#262710](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/262710)